### PR TITLE
Changed Linked in URL

### DIFF
--- a/pages/trainees/Ananya2003Gupta.md
+++ b/pages/trainees/Ananya2003Gupta.md
@@ -14,12 +14,12 @@ website:
 e-mail: ananyaguptawork1@gmail.com
 project_title: Julia Interface Integration for PODIO - Enhancing Functionality and Performance
 project_goal: >
-  The primary objective of this project is to develop a comprehensive Julia backend for the PODIO library, focusing on delivering enhanced functionality and performance. By completing the necessary feature set required for the Julia backend, the project will establish a robust and efficient integration. Thorough testing, with a specific emphasis on performance evaluation, will be conducted to ensure the reliability and efficiency of the Julia backend. Ultimately, the successful implementation of the Julia backend will enable seamless integration into the High-Energy Physics (HEP) ecosystem. This integration will empower researchers and data scientists in the HEP field to harness the combined advantages of PODIO's powerful data modeling capabilities and the high-performance computing environment provided by Julia.
+  The primary objective of this project is to develop a comprehensive Julia backend for the PODIO library, focusing on delivering enhanced functionality and performance. By completing the necessary feature set required for the Julia backend, the project will establish a robust and efficient integration. Thorough testing, with a specific emphasis on performance evaluation, will be conducted to ensure the reliability and efficiency of the Julia backend. The successful implementation of the Julia backend will enable seamless integration into the High-Energy Physics (HEP) ecosystem. This integration will empower researchers and data scientists in the HEP field to harness the combined advantages of PODIO's powerful data modeling capabilities and the high-performance computing environment provided by Julia.
 mentors:
 - Benedikt Hegner (CERN), Graeme A Stewart (CERN)
 proposal: /assets/pdf/Julia_Interface_Integration_for_PODIO-Enhancing_Functionality_and_Performance.pdf
 presentations:
 github-username: Ananya2003Gupta
-linkedin-profile: linkedin.com/in/ananyagupta05
+linkedin-profile: https://www.linkedin.com/in/ananyagupta05/
 current_status: >
 ---


### PR DESCRIPTION
The previously added linked in URL was not working and redirecting to 404 page.
Fixed the linked in URL and made some minor grammatical changes in Project Goals section.